### PR TITLE
images

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,7 +10,7 @@
         <meta name="twitter:site" content="@TAHRIRumich"/>
         <meta name="twitter:title" content="About TAHRIR"/>
         <meta name="twitter:description" content="A student-led movement fighting for divestment from Israel and the war machine"/>
-        <meta name="twitter:image" content="/assets/img/tahrir_logo.jpeg"/>
+        <meta name="twitter:image" content="https://tahrirumich.org/assets/img/about-header-3.jpg" />
         <title>TAHRIR Coalition at the University of Michigan</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Font Awesome icons (free version)-->

--- a/contact.html
+++ b/contact.html
@@ -10,7 +10,7 @@
         <meta name="twitter:site" content="@TAHRIRumich"/>
         <meta name="twitter:title" content="Contact Us"/>
         <meta name="twitter:description" content="Get involved with TAHRIR and the Divest! Don't Arrest campaign"/>
-        <meta name="twitter:image" content="/assets/img/tahrir_logo.jpeg"/>
+        <meta name="twitter:image" content="https://tahrirumich.org/assets/img/contact-bg.jpg" />
         <title>TAHRIR Coalition at the University of Michigan</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Font Awesome icons (free version)-->

--- a/divestdontarrest.html
+++ b/divestdontarrest.html
@@ -10,7 +10,7 @@
         <meta name="twitter:site" content="@TAHRIRumich"/>
         <meta name="twitter:title" content="Divest! Don't Arrest"/>
         <meta name="twitter:description" content="TAHRIR Coalition is launching the Divest! Don't Arrest campaign to demand U-M divest"/>
-        <meta name="twitter:image" content="/assets/img/tahrir_logo.jpeg"/>
+        <meta name="twitter:image" content="https://tahrirumich.org/assets/img/referendum-header.jpg" />
         <title>TAHRIR Coalition at the University of Michigan</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Font Awesome icons (free version)-->

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <meta name="twitter:site" content="@TAHRIRumich"/>
         <meta name="twitter:title" content="TAHRIR Coalition at the University of Michigan"/>
         <meta name="twitter:description" content="A student-led movement fighting for divestment from Israel and the war machine"/>
-        <meta name="twitter:image" content="/assets/img/tahrir_logo.jpeg"/>
+        <meta name="twitter:image" content="https://tahrirumich.org/assets/img/about-header-2.jpg" />
         <title>TAHRIR Coalition at the University of Michigan</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Font Awesome icons (free version)-->

--- a/why-divest.html
+++ b/why-divest.html
@@ -10,7 +10,7 @@
         <meta name="twitter:site" content="@TAHRIRumich"/>
         <meta name="twitter:title" content="Who Does the U-M Endowment Serve?"/>
         <meta name="twitter:description" content="TAHRIR Coalition's Endowment Guide exposes how U-M has invested $6 billion, through its endowment, in the genocide and occupation of Palestine."/>
-        <meta name="twitter:image" content="/assets/img/tahrir_logo.jpeg"/>
+        <meta name="twitter:image" content="https://tahrirumich.org/assets/img/divest_header.jpg" />
         <title>TAHRIR Coalition at the University of Michigan</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Font Awesome icons (free version)-->


### PR DESCRIPTION
adjusted relative->absolute URLs per some stackoverflow posts. Also changed them to match the headers while I was at it, since the logo is a little plain for social media previews

we still have to find a way to refresh the twitter cache -- the method below demonstrates this works on a completely separate URL (I just threw together an endpoint on my own server to test it) but I'm expecting some difficulty in forcing twitter to update the main site's cached images

![02-27-24_23:37:18](https://github.com/tahrirumich/tahrirumich.github.io/assets/10158748/fcd539d9-9120-459c-b03f-5cd0ece28fa9)
